### PR TITLE
Kernel#returning => Object#tap

### DIFF
--- a/lib/technoweenie/attachment_fu.rb
+++ b/lib/technoweenie/attachment_fu.rb
@@ -409,7 +409,7 @@ module Technoweenie # :nodoc:
 
         def sanitize_filename(filename)
           return unless filename
-          returning filename.strip do |name|
+          filename.strip.tap do |name|
             # NOTE: File.basename doesn't work right with Windows paths on Unix
             # get only the filename, not the whole path
             name.gsub! /^.*(\\|\/)/, ''


### PR DESCRIPTION
Hi Rick,

I updated the sanitize_filename method to replace Kernel#returning with Object#tap. I was getting way to many deprecation warnings after updating an app from Rails 2.3.8 to 2.3.12. 

Best regards,

Sven 
