### PR TITLE
Please pull fix for rails 1.2.6

### DIFF
--- a/lib/technoweenie/attachment_fu.rb
+++ b/lib/technoweenie/attachment_fu.rb
@@ -290,11 +290,16 @@ module Technoweenie # :nodoc:
         thumbnailable? || raise(ThumbnailError.new("Can't create a thumbnail if the content type is not an image or there is no parent_id column"))
         returning find_or_initialize_thumbnail(file_name_suffix) do |thumb|
           thumb.temp_paths.unshift temp_file
-          thumb.send(:'attributes=', {
+          thumb_attributes= {
             :content_type             => content_type,
             :filename                 => thumbnail_name_for(file_name_suffix),
             :thumbnail_resize_options => size
-          }, false)
+          }
+          if Rails::VERSION::MAJOR == 1
+            thumb.send(:'attributes=', thumb_attributes)
+          else
+            thumb.send(:'attributes=', thumb_attributes ,false)
+          end
           callback_with_args :before_thumbnail_saved, thumb
           thumb.save!
         end


### PR DESCRIPTION
Hi, Thanks for the great plugin  (and acts_as_attachment),

I would like to submit a fix I did for a clients rails 1.2.6 application. This restores compatibility whilst still leaving the behaviour the same for Rails 2.\* onwards (Ignore mass assignment restrictions when creating thumbnails).

The breakage occurred in commit 9d754014744b039d82e3e55b3cc7f7c35c16ab08
