### PR TITLE
Upgrade Rails ActiveRecord update_all syntax post Rails 2.3.8

### DIFF
--- a/lib/technoweenie/attachment_fu/backends/db_file_backend.rb
+++ b/lib/technoweenie/attachment_fu/backends/db_file_backend.rb
@@ -29,7 +29,8 @@ module Technoweenie # :nodoc:
             if save_attachment?
               (db_file || build_db_file).data = temp_data
               db_file.save!
-              self.class.update_all ['db_file_id = ?', self.db_file_id = db_file.id], ['id = ?', id]
+              self.db_file_id = db_file.id
+              self.class.where(:id => id).update_all(:db_file_id => db_file.id)
             end
             true
           end


### PR DESCRIPTION
ActiveRecord#update_all was deprecated in Rails 2.3.8 and has since been replaced by ActiveRecord::Relation#update_all.  With this change the method signature (accepted parameters) and usage have also changed requiring the refactoring.
