### PR TITLE
Fixed and improved error messages

### DIFF
--- a/attachment_fu.gemspec
+++ b/attachment_fu.gemspec
@@ -1,0 +1,21 @@
+Gem::Specification.new do |s|
+  s.name			  = %q{attachment_fu}
+  s.authors			  = ["Rick Olson", "Steven Pothoven", "Eduard Martini"]
+  s.summary			  = %q{attachment_fu as a gem}
+  s.description		  = %q{This is a fork of Steven Pothoven's attachment_fu fixing some validation errors.}
+  s.email			  = %q{eduard.martini@gmail.com}
+  s.homepage		  = %q{http://github.com/eduardm/attachment_fu}
+  s.version			  = "3.2.19"
+  s.date			  = %q{2017-01-02}
+
+  s.files			  = Dir.glob("{lib,vendor}/**/*") + %w( CHANGELOG LICENSE README.rdoc amazon_s3.yml.tpl rackspace_cloudfiles.yml.tpl )
+  s.extra_rdoc_files  = ["README.rdoc"]
+  s.rdoc_options	  = ["--inline-source", "--charset=UTF-8"]
+  s.require_paths	  = ["lib"]
+  s.rubyforge_project = "nowarning"
+  s.rubygems_version  = %q{1.8.29}
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 2
+  end
+end

--- a/lib/technoweenie/attachment_fu.rb
+++ b/lib/technoweenie/attachment_fu.rb
@@ -426,13 +426,15 @@ module Technoweenie # :nodoc:
 
         # validates the size and content_type attributes according to the current model's options
         def attachment_attributes_valid?
-          [:size, :content_type].each do |attr_name|
-            enum = attachment_options[attr_name]
-            if Object.const_defined?(:I18n) # Rails >= 2.2
-              errors.add attr_name, I18n.translate("activerecord.errors.messages.inclusion", attr_name => enum) unless enum.nil? || enum.include?(send(attr_name))
-            else
-              errors.add attr_name, ActiveRecord::Errors.default_error_messages[:inclusion] unless enum.nil? || enum.include?(send(attr_name))
-            end
+          content_type = attachment_options[:content_type]
+          if Object.const_defined?(:I18n) # Rails >= 2.2
+            errors.add :content_type, I18n.translate("errors.messages.inclusion", attr_name => content_type) unless content_type.nil? || content_type.include?(send(:content_type))
+            errors.add :size, I18n.translate("errors.messages.less_than", count: attachment_options[:max_size]) if send(:size) > attachment_options[:max_size]
+            errors.add attr_name, I18n.translate("errors.messages.greater_than", count: attachment_options[:min_size]) if send(:size) < attachment_options[:min_size]
+          else
+            errors.add :content_type, ActiveRecord::Errors.default_error_messages[:inclusion] unless content_type.nil? || content_type.include?(send(:content_type))
+            errors.add :size, ActiveRecord::Errors.default_error_messages[:less_than] if send(:size) > attachment_options[:max_size]
+            errors.add :size, ActiveRecord::Errors.default_error_messages[:greater_than] if send(:size) < attachment_options[:min_size]
           end
         end
 


### PR DESCRIPTION
Fixed Validation failed: Attachment translation missing: en.activerecord.errors.messages.inclusion and added separate error messages for size and content type.